### PR TITLE
Auth changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bottlesession"]
+	path = bottlesession
+	url = https://github.com/utwente-fmt/bottlesession

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,75 @@
+################################
+# Authentication
+################################
+
+import ldap
+from sys import stdout
+
+
+auth_info = { 'credentials': {} }
+
+def check_credentials_basic(username, password):
+    if password and auth_info['credentials'].get(username) == password:
+        return None
+    else:
+        return 'unknown user or invalid password'
+
+# from https://gist.github.com/1288159
+def check_credentials_ldap(username, password):
+    """Verifies credentials for username and password.
+    Returns None on success or a string describing the error on failure
+    # Adapt to your needs
+    """
+    print 'check_credentials_ldap username='+str(username)
+    stdout.flush()
+
+    LDAP_SERVER = auth_info['ldapserver']
+    # fully qualified AD user name
+    LDAP_USERNAME = auth_info['ldapuserformat'] % username
+    # your password
+    LDAP_PASSWORD = password
+    base_dn = auth_info['ldapbasedn']
+    ldap_filter = auth_info['ldapfilterformat'] % username
+    attrs = auth_info['ldapattributes']
+    try:
+        # build a client
+        ldap_client = ldap.initialize(LDAP_SERVER)
+        # perform a synchronous bind
+        ldap_client.set_option(ldap.OPT_REFERRALS,0)
+        ldap_client.simple_bind_s(LDAP_USERNAME, LDAP_PASSWORD)
+    except ldap.INVALID_CREDENTIALS:
+        ldap_client.unbind()
+        print 'check_credentials_ldap username='+str(username)+' : '+'Wrong username ili password'
+        stdout.flush()
+        return 'Wrong username ili password'
+    except ldap.SERVER_DOWN:
+        print 'check_credentials_ldap username='+str(username)+' : '+'AD server not available'
+        stdout.flush()
+        return 'AD server not available'
+    # all is well
+    # get all user groups and store it in cerrypy session for future use
+    values = ldap_client.search_s(base_dn, ldap.SCOPE_SUBTREE, ldap_filter, attrs)
+    ldap_client.unbind()
+    dept_ok = False
+    for dn, entry in values:
+        print 'check_credentials_ldap search result: dn: '+str(dn)+' entry: '+str(entry)
+        if dn != None:
+            dept_ok = True
+    if not dept_ok:
+        print 'check_credentials_ldap username='+str(username)+' : '+ auth_info['ldapfiltererrmessage']
+        stdout.flush()
+        return 'wrong department'
+    print 'check_credentials_ldap username='+str(username)+' : '+'None'
+    stdout.flush()
+    return None
+
+def auth_config(key, val):
+    auth_info[key] = val
+
+def auth_check_credentials(auth, username, password):
+    if auth == 'ldap':
+        return check_credentials_ldap(username, password)
+    else:
+        return check_credentials_basic(username, password)
+
+

--- a/misc/stunnel.conf
+++ b/misc/stunnel.conf
@@ -1,8 +1,5 @@
-# cert = /etc/ssl/screenly.crt
-# key = /etc/ssl/screenly.key
-cert = /etc/ssl/cert-11024-fmtwallrasp.ewi.utwente.nl.pem
-key = /etc/ssl/server.key
-CAfile = /etc/ssl/chain-11024-fmtwallrasp.ewi.utwente.nl.pem
+cert = /etc/ssl/screenly.crt
+key = /etc/ssl/screenly.key
 pid = /tmp/stunnel4.pid
 
 [https]

--- a/misc/stunnel.conf
+++ b/misc/stunnel.conf
@@ -1,5 +1,8 @@
-cert = /etc/ssl/screenly.crt
-key = /etc/ssl/screenly.key
+# cert = /etc/ssl/screenly.crt
+# key = /etc/ssl/screenly.key
+cert = /etc/ssl/cert-11024-fmtwallrasp.ewi.utwente.nl.pem
+key = /etc/ssl/server.key
+CAfile = /etc/ssl/chain-11024-fmtwallrasp.ewi.utwente.nl.pem
 pid = /tmp/stunnel4.pid
 
 [https]

--- a/server.py
+++ b/server.py
@@ -66,18 +66,22 @@ if settings['auth'] == 'ldap':
     ldap_u_attr = json.loads(settings['ldapattributes'])
     ldapattr = []
     for a in ldap_u_attr:
-       ldapattr.append(str(a))
+        ldapattr.append(str(a))
     auth_config('ldapattributes', ldapattr)
-elif settings['auth'] == 'basic' and settings['username'] and settings['password']:
-    credentials = { settings['username'] : settings['password'] }
-    auth_config('credentials', { settings['username'] : settings['password'] })
+elif (settings['auth'] == 'basic' and
+      settings['username'] and settings['password']):
+    credentials = {settings['username']: settings['password']}
+    auth_config('credentials', {settings['username']: settings['password']})
 elif settings['auth'] == 'basic':
-    print 'Cannot use '+str(settings['auth'])+' authentication in web interface,'
-    print ' because username and/or password are not set in screenly config-file.'
+    print ('Cannot use '+str(settings['auth']) +
+           ' authentication in web interface,')
+    print (' because username and/or password' +
+           ' are not set in screenly config-file.')
     stdout.flush()
     auth = None
-elif settings['auth'] != None:
-    print 'Cannot use '+str(settings['auth'])+' authentication in web interface: unknown auth type.'
+elif settings['auth'] is not None:
+    print ('Cannot use '+str(settings['auth']) +
+           ' authentication in web interface: unknown auth type.')
     stdout.flush()
     auth = None
 
@@ -90,9 +94,11 @@ else:
     print 'To enable authentication in web interface,'
     print ' specify auth in the config-file.'
     stdout.flush()
-    session_manager = bottlesession.PreconfiguredSession({'valid':True, 'name': '', 'new': False})
+    session_manager = bottlesession.PreconfiguredSession(
+        {'valid': True, 'name': '', 'new': False})
 
-valid_user = bottlesession.authenticator(session_manager, login_scheme=settings['proto'])
+valid_user = bottlesession.authenticator(
+    session_manager, login_scheme=settings['proto'])
 
 
 ################################
@@ -169,18 +175,6 @@ def login():
     stdout.flush()
 
     context = {'flash': None}
-
-    #if (request.POST.get('name','').strip() and
-    #    request.POST.get('password','').strip()
-    #    ):
-    #
-    #    name =  request.POST.get('name','').strip()
-    #    password = request.POST.get('password','').strip()
-    #    if (name, password) == ('rott', 'hackme'):
-    #           return template('index')
-    #
-    # return template('login')
-
     session = session_manager.get_session()
     session['valid'] = False
 
@@ -198,8 +192,9 @@ def login():
         stdout.flush()
         return template('login', **context)
 
-    check_err_msg = auth_check_credentials(settings['auth'], username, password)
-    if check_err_msg == None:
+    check_err_msg = auth_check_credentials(
+        settings['auth'], username, password)
+    if check_err_msg is None:
         session['valid'] = True
         session['name'] = username
 
@@ -213,9 +208,8 @@ def login():
         return template('login', **context)
 
     redirpath = request.get_cookie('validuserloginredirect')
-    if redirpath == None:
+    if redirpath is None:
         urlparts = request.urlparts
-        #redirpath = urlparts.scheme + '://' + urlparts.netloc + '/'
         redirpath = settings['proto'] + '://' + urlparts.netloc + '/'
     print 'login username='+str(username)+' : ok, redirect : '+redirpath
     stdout.flush()
@@ -231,11 +225,8 @@ def logout():
     session['valid'] = False
     session_manager.save(session)
     urlparts = request.urlparts
-    #redirpath = urlparts.scheme + '://' + urlparts.netloc + '/'
     redirpath = settings['proto'] + '://' + urlparts.netloc + '/'
     redirect(redirpath)
-
-
 
 
 ################################

--- a/server.py
+++ b/server.py
@@ -92,7 +92,7 @@ else:
     stdout.flush()
     session_manager = bottlesession.PreconfiguredSession({'valid':True, 'name': '', 'new': False})
 
-valid_user = bottlesession.authenticator(session_manager, login_proto=settings['proto'])
+valid_user = bottlesession.authenticator(session_manager, login_scheme=settings['proto'])
 
 
 ################################

--- a/server.py
+++ b/server.py
@@ -35,6 +35,66 @@ from utils import url_fails
 from utils import get_video_duration
 
 from settings import settings, DEFAULTS
+
+
+from sys import path as sys_path
+from sys import stdout
+
+from bottle import redirect
+sys_path.append('bottlesession')
+import bottlesession
+
+# stuff for nicer logging
+from bottle import app as bottle_app
+from paste.translogger import TransLogger
+from auth import auth_check_credentials, auth_config
+
+################################
+
+logapp = TransLogger(bottle_app())
+
+# Initialize session manager
+if settings['auth'] == 'ldap':
+    # nothing to do here
+    pass
+    auth_config('ldapserver', settings['ldapserver'])
+    auth_config('ldapuserformat', settings['ldapuserformat'])
+    auth_config('ldapbasedn', settings['ldapbasedn'])
+    auth_config('ldapfilterformat', settings['ldapfilterformat'])
+    auth_config('ldapfiltererrmessage', settings['ldapfiltererrmessage'])
+    # strip unicode notation like:  u'some text string'
+    ldap_u_attr = json.loads(settings['ldapattributes'])
+    ldapattr = []
+    for a in ldap_u_attr:
+       ldapattr.append(str(a))
+    auth_config('ldapattributes', ldapattr)
+elif settings['auth'] == 'basic' and settings['username'] and settings['password']:
+    credentials = { settings['username'] : settings['password'] }
+    auth_config('credentials', { settings['username'] : settings['password'] })
+elif settings['auth'] == 'basic':
+    print 'Cannot use '+str(settings['auth'])+' authentication in web interface,'
+    print ' because username and/or password are not set in screenly config-file.'
+    stdout.flush()
+    auth = None
+elif settings['auth'] != None:
+    print 'Cannot use '+str(settings['auth'])+' authentication in web interface: unknown auth type.'
+    stdout.flush()
+    auth = None
+
+if settings['auth']:
+    session_manager = bottlesession.MemorySession()
+    print 'Using '+str(settings['auth'])+' authentication in web interface.'
+    stdout.flush()
+else:
+    print 'Not using authentication in web interface.'
+    print 'To enable authentication in web interface,'
+    print ' specify auth in the config-file.'
+    stdout.flush()
+    session_manager = bottlesession.PreconfiguredSession({'valid':True, 'name': '', 'new': False})
+
+valid_user = bottlesession.authenticator(session_manager, login_proto=settings['proto'])
+
+
 ################################
 # Utilities
 ################################
@@ -91,8 +151,91 @@ def template(template_name, **context):
     # Add global contexts
     context['up_to_date'] = is_up_to_date()
     context['default_duration'] = settings['default_duration']
+    try:
+        context['username'] = request.environ['REMOTE_USER']
+    except:
+        context['username'] = None
 
     return haml_template(template_name, **context)
+
+
+@route('/auth/login', method='POST')
+@route('/auth/login', method='GET')
+def login():
+    username = request.POST.get('username')
+    password = request.POST.get('password')
+
+    print 'login username='+str(username)
+    stdout.flush()
+
+    context = {'flash': None}
+
+    #if (request.POST.get('name','').strip() and
+    #    request.POST.get('password','').strip()
+    #    ):
+    #
+    #    name =  request.POST.get('name','').strip()
+    #    password = request.POST.get('password','').strip()
+    #    if (name, password) == ('rott', 'hackme'):
+    #           return template('index')
+    #
+    # return template('login')
+
+    session = session_manager.get_session()
+    session['valid'] = False
+
+    if request.method == 'POST' and session['new']:
+        message = "Cookies must be enabled to be able to authenticate."
+        context['flash'] = {'class': "success", 'message': message}
+        print 'login username='+str(username)+' : message: '+message
+        stdout.flush()
+        return template('login', **context)
+
+    if not username or not password:
+        message = "Please specify username and password"
+        context['flash'] = {'class': "success", 'message': message}
+        print 'login username='+str(username)+' : message: '+message
+        stdout.flush()
+        return template('login', **context)
+
+    check_err_msg = auth_check_credentials(settings['auth'], username, password)
+    if check_err_msg == None:
+        session['valid'] = True
+        session['name'] = username
+
+    session_manager.save(session)
+
+    if not session['valid']:
+        error = "Username or password is invalid: " + check_err_msg
+        context['flash'] = {'class': "error", 'message': error}
+        print 'login username='+str(username)+' : error: '+error
+        stdout.flush()
+        return template('login', **context)
+
+    redirpath = request.get_cookie('validuserloginredirect')
+    if redirpath == None:
+        urlparts = request.urlparts
+        #redirpath = urlparts.scheme + '://' + urlparts.netloc + '/'
+        redirpath = settings['proto'] + '://' + urlparts.netloc + '/'
+    print 'login username='+str(username)+' : ok, redirect : '+redirpath
+    stdout.flush()
+    redirect(redirpath)
+
+
+@route('/auth/logout')
+@valid_user()
+def logout():
+    # actually, instead of marking session as invalid, we should just delete it
+    # unfortunately, the session manager does not allow us to do that (yet?)
+    session = session_manager.get_session()
+    session['valid'] = False
+    session_manager.save(session)
+    urlparts = request.urlparts
+    #redirpath = urlparts.scheme + '://' + urlparts.netloc + '/'
+    redirpath = settings['proto'] + '://' + urlparts.netloc + '/'
+    redirect(redirpath)
+
+
 
 
 ################################
@@ -195,6 +338,7 @@ def prepare_asset(request):
 
 
 @route('/api/assets', method="GET")
+@valid_user()
 def api_assets():
     assets = assets_helper.read(db_conn)
     return make_json_response(assets)
@@ -215,6 +359,7 @@ def api(view):
 
 
 @route('/api/assets', method="POST")
+@valid_user()
 @api
 def add_asset():
     asset = prepare_asset(request)
@@ -224,18 +369,21 @@ def add_asset():
 
 
 @route('/api/assets/:asset_id', method="GET")
+@valid_user()
 @api
 def edit_asset(asset_id):
     return assets_helper.read(db_conn, asset_id)
 
 
 @route('/api/assets/:asset_id', method=["PUT", "POST"])
+@valid_user()
 @api
 def edit_asset(asset_id):
     return assets_helper.update(db_conn, asset_id, prepare_asset(request))
 
 
 @route('/api/assets/:asset_id', method="DELETE")
+@valid_user()
 @api
 def remove_asset(asset_id):
     asset = assets_helper.read(db_conn, asset_id)
@@ -249,6 +397,7 @@ def remove_asset(asset_id):
 
 
 @route('/api/assets/order', method="POST")
+@valid_user()
 @api
 def playlist_order():
     "Receive a list of asset_ids in the order they should be in the playlist"
@@ -261,11 +410,13 @@ def playlist_order():
 
 
 @route('/')
+@valid_user()
 def viewIndex():
     return template('index')
 
 
 @route('/settings', method=["GET", "POST"])
+@valid_user()
 def settings_page():
 
     context = {'flash': None}
@@ -290,7 +441,9 @@ def settings_page():
 
 
 @route('/system_info')
+@valid_user()
 def system_info():
+    context = {'flash': None}
     viewer_log_file = '/tmp/screenly_viewer.log'
     if path.exists(viewer_log_file):
         viewlog = check_output(['tail', '-n', '20', viewer_log_file]).split('\n')
@@ -322,7 +475,7 @@ def splash_page():
     my_ip = get_node_ip()
     if my_ip:
         ip_lookup = True
-        url = "http://{}:{}".format(my_ip, settings.get_listen_port())
+        url = settings['proto']+"://{}:{}".format(my_ip, settings.get_listen_port())
     else:
         ip_lookup = False
         url = "Unable to look up your installation's IP address."
@@ -366,4 +519,6 @@ if __name__ == "__main__":
                 c.execute(assets_helper.create_assets_table)
         run(host=settings.get_listen_ip(),
             port=settings.get_listen_port(),
-            reloader=True)
+            app=logapp,
+            quiet=True,
+            reloader=False)

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,17 @@ DEFAULTS = {
     'main': {
         'database': CONFIG_DIR + 'screenly.db',
         'listen': '0.0.0.0:8080',
+	'proto': 'http',
         'assetdir': 'screenly_assets',
+        'auth': None,
+        'username': None,
+        'password': None,
+        'ldapserver': None,
+        'ldapuserformat': None,
+        'ldapbasedn': None,
+        'ldapfilterformat': None,
+        'ldapfiltererrmessage': None,
+        'ldapattributes': None,
     },
     'viewer': {
         'show_splash': True,

--- a/views/index.haml
+++ b/views/index.haml
@@ -188,6 +188,11 @@
               %a(href="/system_info")
                 %i.icon-tasks.icon-white
                 System Info
+            - if username != None:
+              %li.divider-vertical
+              %li
+                %a(href="/auth/logout")
+                  Logout ${username}
 
     .container
       .row

--- a/views/index.haml
+++ b/views/index.haml
@@ -190,7 +190,7 @@
               %a(href="/system_info")
                 %i.icon-tasks.icon-white
                 System Info
-            - if username != None:
+            - if username is not None:
               %li.divider-vertical
               %li
                 %a(href="/auth/logout")

--- a/views/settings.haml
+++ b/views/settings.haml
@@ -34,7 +34,7 @@
               %a(href="/system_info")
                 %i.icon-tasks.icon-white
                 System Info
-            - if username != None:
+            - if username is not None:
               %li.divider-vertical
               %li
                 %a(href="/auth/logout")

--- a/views/settings.haml
+++ b/views/settings.haml
@@ -34,6 +34,11 @@
               %a(href="/system_info")
                 %i.icon-tasks.icon-white
                 System Info
+            - if username != None:
+              %li.divider-vertical
+              %li
+                %a(href="/auth/logout")
+                  Logout ${username}
 
     .container
       .row

--- a/views/system_info.haml
+++ b/views/system_info.haml
@@ -33,6 +33,11 @@
               %a(href="/system_info")
                 %i.icon-tasks.icon-white
                 System Info
+            - if username != None:
+              %li.divider-vertical
+              %li
+                %a(href="/auth/logout")
+                  Logout ${username}
 
     .container
       .row

--- a/views/system_info.haml
+++ b/views/system_info.haml
@@ -33,7 +33,7 @@
               %a(href="/system_info")
                 %i.icon-tasks.icon-white
                 System Info
-            - if username != None:
+            - if username is not None:
               %li.divider-vertical
               %li
                 %a(href="/auth/logout")


### PR DESCRIPTION
For your information: the changes I made to enable (basic and) ldap authentication.

Note: to use this, you need:
     sudo apt-get install python-paste
     sudo apt-get install python-ldap

Note that I run this via stunnel, set-up via the ~/screenly/misc/enable_ssl.sh script provided with screenly.
Note that when you enable stunnel using that script, you have to change the firewall rules to open port 443, by issuing: sudo ufw allow 443/tcp
Probably this should be fixed in the ~/screenly/misc/enable_ssl.sh script.

(Edited to include 'sudo apt-get install python-ldap')

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/224)
<!-- Reviewable:end -->
