### PR TITLE
GH-243 Fix unicode bug

### DIFF
--- a/server.py
+++ b/server.py
@@ -114,7 +114,12 @@ def prepare_asset(request):
 
     def get(key):
         val = data.get(key, '')
-        return val.strip() if isinstance(val, basestring) else val
+        if isinstance(val, unicode):
+            return val.strip()
+        elif isinstance(val, basestring):
+            return val.strip().decode('utf-8')
+        else:
+            return val
 
     if all([get('name'),
             get('uri') or (request.files.file_upload != ""),


### PR DESCRIPTION
Here's a fix for GH-243

This was a regression from GH-226. Basically I should have tested the case where the asset is uploaded. That's what the decode('utf-8') was for originally.

When an asset is upload, it gets uploaded as multipart/form-data. The form metadata for the asset gets posted as individual params instead of in one JSON encoded string via a param named model.

Since the data is not in JSON encoded string format, we skip the JSON decoding that converts the form data to unicode automatically.

This means we have to decode to utf-8 in this case. Here I make the assumption that utf-8 will always be the encoding if using Screenly's admin interface.

I did spend quite a bit of time trying to figure how to pass "Accept-Charset" using jQuery File upload, but it never added the header. You can add the `accept-charset` attribute to a form and jQuery File upload should look for it. You can also set the `formAcceptCharset` variable in the options. This had no effect though. Wasn't sure why.

Test Procedure:

1. Upload image file
2. Use unicode text for title
3. Save

1. Create asset using URL asset
2. Use unicode text for title
3. Save

Both should pass.