### PR TITLE
fix asset time change after update

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -7,6 +7,8 @@ from sh import grep, netstat
 from urlparse import urlparse
 from datetime import timedelta
 from settings import settings
+from datetime import datetime
+import pytz
 
 HTTP_OK = xrange(200, 299)
 
@@ -79,8 +81,10 @@ def get_video_duration(file):
 
 
 def handler(obj):
-    if hasattr(obj, 'isoformat'):
-        return obj.isoformat()
+    # Set timezone as UTC if it's datetime and format as ISO
+    if isinstance(obj, datetime):
+        with_tz = obj.replace(tzinfo=pytz.utc)
+        return with_tz.isoformat()
     else:
         raise TypeError('Object of type %s with value of %s is not JSON serializable' % (type(obj), repr(obj)))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ six==1.8.0
 uptime==2.0.2
 werkzeug==0.10.4
 wsgiref==0.1.2
+python-dateutil==2.4.2

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ from lib.utils import get_node_ip
 from lib.utils import validate_url
 from lib.utils import url_fails
 from lib.utils import get_video_duration
+from dateutil import parser as date_parser
 
 from settings import settings, DEFAULTS, CONFIGURABLE_SETTINGS
 from werkzeug.wrappers import Request
@@ -173,13 +174,14 @@ def prepare_asset(request):
             # Crashes if it's not an int. We want that.
             asset['duration'] = int(get('duration'))
 
+        # parse date via python-dateutil and remove timezone info
         if get('start_date'):
-            asset['start_date'] = datetime.strptime(get('start_date').split(".")[0], "%Y-%m-%dT%H:%M:%S")
+            asset['start_date'] = date_parser.parse(get('start_date')).replace(tzinfo=None)
         else:
             asset['start_date'] = ""
 
         if get('end_date'):
-            asset['end_date'] = datetime.strptime(get('end_date').split(".")[0], "%Y-%m-%dT%H:%M:%S")
+            asset['end_date'] = date_parser.parse(get('end_date')).replace(tzinfo=None)
         else:
             asset['end_date'] = ""
 

--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -69,8 +69,6 @@ API.Asset = class Asset extends Backbone.Model
   active: =>
     if @get('is_enabled') and @get('start_date') and @get('end_date')
       at = now()
-      # Provide correct format for Date.parse
-      # Tell to browser that it is UTC + 0 (Z = zero)
       start_date = new Date(@get('start_date'));
       end_date = new Date(@get('end_date'));
       return start_date <= at <= end_date

--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -20,7 +20,7 @@ date_settings = if use_24_hour_clock then date_settings_24hour else date_setting
 
 
 API.date_to = date_to = (d) ->
-  #cross-browser utc to localtime convertion
+  # Cross-browser UTC to localtime conversion
   dd = moment.utc(d).local()
   string: -> dd.format date_settings.full_date
   date: -> dd.format date_settings.date

--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -71,8 +71,8 @@ API.Asset = class Asset extends Backbone.Model
       at = now()
       # Provide correct format for Date.parse
       # Tell to browser that it is UTC + 0 (Z = zero)
-      start_date = new Date(@get('start_date') + 'Z');
-      end_date = new Date(@get('end_date') + 'Z');
+      start_date = new Date(@get('start_date'));
+      end_date = new Date(@get('end_date'));
       return start_date <= at <= end_date
     else
       return false

--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -20,7 +20,8 @@ date_settings = if use_24_hour_clock then date_settings_24hour else date_setting
 
 
 API.date_to = date_to = (d) ->
-  dd = moment (new Date d)
+  #cross-browser utc to localtime convertion
+  dd = moment.utc(d).local()
   string: -> dd.format date_settings.full_date
   date: -> dd.format date_settings.date
   time: -> dd.format date_settings.time
@@ -68,8 +69,10 @@ API.Asset = class Asset extends Backbone.Model
   active: =>
     if @get('is_enabled') and @get('start_date') and @get('end_date')
       at = now()
-      start_date = new Date(@get('start_date'));
-      end_date = new Date(@get('end_date'));
+      # Provide correct format for Date.parse
+      # Tell to browser that it is UTC + 0 (Z = zero)
+      start_date = new Date(@get('start_date') + 'Z');
+      end_date = new Date(@get('end_date') + 'Z');
       return start_date <= at <= end_date
     else
       return false

--- a/static/js/screenly-ose.js
+++ b/static/js/screenly-ose.js
@@ -131,8 +131,8 @@
       var at, end_date, start_date;
       if (this.get('is_enabled') && this.get('start_date') && this.get('end_date')) {
         at = now();
-        start_date = new Date(this.get('start_date') + 'Z');
-        end_date = new Date(this.get('end_date') + 'Z');
+        start_date = new Date(this.get('start_date'));
+        end_date = new Date(this.get('end_date'));
         return (start_date <= at && at <= end_date);
       } else {
         return false;

--- a/static/js/screenly-ose.js
+++ b/static/js/screenly-ose.js
@@ -32,7 +32,7 @@
 
   API.date_to = date_to = function(d) {
     var dd;
-    dd = moment(new Date(d));
+    dd = moment.utc(d).local();
     return {
       string: function() {
         return dd.format(date_settings.full_date);
@@ -131,8 +131,8 @@
       var at, end_date, start_date;
       if (this.get('is_enabled') && this.get('start_date') && this.get('end_date')) {
         at = now();
-        start_date = new Date(this.get('start_date'));
-        end_date = new Date(this.get('end_date'));
+        start_date = new Date(this.get('start_date') + 'Z');
+        end_date = new Date(this.get('end_date') + 'Z');
         return (start_date <= at && at <= end_date);
       } else {
         return false;


### PR DESCRIPTION
Use moment for crossbrowser convert utc to localtime. Spec for Date.parse (new Date) requires timezone. Server does not knows about timezones. We need to add 'Z' to provided by server string instead some browsers( IE and FF) will think that it is localtime

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/318)
<!-- Reviewable:end -->
