### PR TITLE
Small bug fix for servers that do not support HEAD

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -93,7 +93,7 @@ def url_fails(url):
     """
     try:
         if validate_url(url):
-            obj = requests.head(url, allow_redirects=True, timeout=10, verify=settings['verify_ssl'])
+            obj = requests.get(url, allow_redirects=True, timeout=10, verify=settings['verify_ssl'])
             assert obj.status_code in (200, 405)
     except (requests.ConnectionError, requests.exceptions.Timeout, AssertionError):
         return True


### PR DESCRIPTION
It took me awhile to track this down, when putting in the URL it returned an error that the file could not be found. Putting the URL into the browser returned status code 200. After doing a little research I discovered the the server does not support HEAD and will return a 404. However when doing a GET it will return a 200.

This should solve a problem for a small minority of users.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/350)
<!-- Reviewable:end -->
