### PR TITLE
Save 24 clock setting when amended in UI

### DIFF
--- a/server.py
+++ b/server.py
@@ -34,7 +34,7 @@ from utils import validate_url
 from utils import url_fails
 from utils import get_video_duration
 
-from settings import settings, DEFAULTS
+from settings import settings, DEFAULTS, CONFIGURABLE_SETTINGS
 from werkzeug.wrappers import Request
 ################################
 # Utilities
@@ -273,7 +273,7 @@ def settings_page():
     context = {'flash': None}
 
     if request.method == "POST":
-        for field, default in DEFAULTS['viewer'].items():
+        for field, default in CONFIGURABLE_SETTINGS.items():
             value = request.POST.get(field, default)
             if isinstance(default, bool):
                 value = value == 'on'

--- a/settings.py
+++ b/settings.py
@@ -26,6 +26,8 @@ DEFAULTS = {
         'verify_ssl': True,
     }
 }
+CONFIGURABLE_SETTINGS = DEFAULTS['viewer']
+CONFIGURABLE_SETTINGS['use_24_hour_clock'] = DEFAULTS['main']['use_24_hour_clock']
 
 # Initiate logging
 logging.basicConfig(level=logging.INFO,


### PR DESCRIPTION
Addresses #333 - 24 hr clock setting not applied

Add CONFIGURABLE_SETTINGS dict to settings file and
iterate when saving settings from UI

UI settings include use_24_hour_clock setting, but only the
DEFAULTS['viewer'] dict were being checked, resulting in the time
preference not being persisted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/365)
<!-- Reviewable:end -->
