### PR TITLE
Disable swap

### DIFF
--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -103,3 +103,4 @@
   file:
     path: /var/swap
     state: absent
+    removes: /var/swap

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -97,9 +97,7 @@
     group: root
 
 - name: Disables swap
-  commmand: /sbin/swapoff --all
-  args:
-    removes: /var/swap
+  command: /sbin/swapoff --all removes=/var/swap
 
 - name: Removes swapfile from disk
   file:

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -98,6 +98,8 @@
 
 - name: Disables swap
   commmand: /sbin/swapoff --all
+  args:
+    removes: /var/swap
 
 - name: Removes swapfile from disk
   file:

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -105,4 +105,3 @@
   file:
     path: /var/swap
     state: absent
-    removes: /var/swap

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -81,6 +81,7 @@
     - supervisor
     - lightdm
     - lightdm-gtk-greeter
+    - dphys-swapfile
 
 - name: Removing deprecated pip dependencies
   pip:
@@ -94,3 +95,11 @@
     mode: 0755
     owner: root
     group: root
+
+- name: Disables swap
+  commmand: /sbin/swapoff --all
+
+- name: Removes swapfile from disk
+  file:
+    path: /var/swap
+    state: absent

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -3,7 +3,7 @@ set -xe
 sudo apt-get update
 sudo apt-get install -y python-dev python-setuptools git-core
 sudo easy_install pip
-sudo pip install ansible==2.0.1.0
+sudo pip install ansible==2.0.2.0
 
 ansible localhost -m git -a "repo=${1:-http://github.com/wireload/screenly-ose.git} dest=/home/pi/screenly version=${2:-master}"
 cd /home/pi/screenly/ansible


### PR DESCRIPTION
Using a swapfile on an SD card is a sure way of trashing it and dramatically shorten the life span. It's much better to kill the `oom-killer` kill processes than the SD card wearing out.