### PR TITLE
Fixes Gunicorn timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER Viktor Petersson <vpetersson@wireload.net>
 
 RUN apt-get update && \
@@ -14,7 +14,7 @@ RUN useradd pi
 
 # Install config file and file structure
 RUN mkdir -p /home/pi/.screenly /home/pi/screenly /home/pi/screenly_assets
-COPY misc/screenly.conf /home/pi/.screenly/screenly.conf
+COPY ansible/roles/screenly/files/screenly.conf /home/pi/.screenly/screenly.conf
 RUN chown -R pi:pi /home/pi
 
 # Copy in code base
@@ -24,6 +24,5 @@ USER pi
 WORKDIR /home/pi/screenly
 
 EXPOSE 8080
-VOLUME /home/pi/screenly
 
 CMD python server.py

--- a/server.py
+++ b/server.py
@@ -383,4 +383,5 @@ if __name__ == "__main__":
             host=settings.get_listen_ip(),
             port=settings.get_listen_port(),
             server='gunicorn',
+            timeout=240,
         )


### PR DESCRIPTION
Bumps up timeout to 240s. This isn't a proper fix to large uploads, but rather a bandaid. A proper fix would be to chunk the uploads to mitigate the timeout issue entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/405)
<!-- Reviewable:end -->
