### PR TITLE
Refs #413. Override user agent for requests to match uzbl.

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -104,14 +104,29 @@ def url_fails(url):
     else:
         verify = False
 
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/538.15 (KHTML, like Gecko) Version/8.0 Safari/538.15',
+    }
     try:
         if not validate_url(url):
             return False
 
-        if requests.head(url, allow_redirects=True, timeout=10, verify=verify).status_code in HTTP_OK:
+        if requests.head(
+            url,
+            allow_redirects=True,
+            headers=headers,
+            timeout=10,
+            verify=verify
+        ).status_code in HTTP_OK:
             return False
 
-        if requests.get(url, allow_redirects=True, timeout=10, verify=verify).status_code in HTTP_OK:
+        if requests.get(
+            url,
+            allow_redirects=True,
+            headers=headers,
+            timeout=10,
+            verify=verify
+        ).status_code in HTTP_OK:
             return False
 
     except (requests.ConnectionError, requests.exceptions.Timeout):


### PR DESCRIPTION
Solves issue with certain Web Application Firewalls (WAF) that blocks the user agent from [Python Requests](http://docs.python-requests.org/en/master/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/417)
<!-- Reviewable:end -->
