### PR TITLE
Ensure the Dockerfile works with current version of PIP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN apt-get update && \
     apt-get clean
 
 # Install Python requirements
+RUN pip install web.py
 ADD requirements.txt /tmp/requirements.txt
+RUN pip install --upgrade cffi
 RUN pip install -r /tmp/requirements.txt
 
 # Create runtime user
@@ -15,10 +17,10 @@ RUN useradd pi
 # Install config file and file structure
 RUN mkdir -p /home/pi/.screenly /home/pi/screenly /home/pi/screenly_assets
 COPY ansible/roles/screenly/files/screenly.conf /home/pi/.screenly/screenly.conf
-RUN chown -R pi:pi /home/pi
 
 # Copy in code base
 COPY . /home/pi/screenly
+RUN chown -R pi:pi /home/pi
 
 USER pi
 WORKDIR /home/pi/screenly

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update && \
     apt-get clean
 
 # Install Python requirements
-RUN pip install web.py
 ADD requirements.txt /tmp/requirements.txt
 RUN pip install --upgrade cffi
 RUN pip install -r /tmp/requirements.txt


### PR DESCRIPTION
I was unable to create a docker due to PIP issues. Using these fixes, building the docker works fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/464)
<!-- Reviewable:end -->
