### PR TITLE
Ensure the Dockerfile works with current version of PIP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ RUN useradd pi
 # Install config file and file structure
 RUN mkdir -p /home/pi/.screenly /home/pi/screenly /home/pi/screenly_assets
 COPY ansible/roles/screenly/files/screenly.conf /home/pi/.screenly/screenly.conf
-RUN chown -R pi:pi /home/pi
 
 # Copy in code base
 COPY . /home/pi/screenly
+RUN chown -R pi:pi /home/pi
 
 USER pi
 WORKDIR /home/pi/screenly

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ PyHAML==0.1.9
 ansible==2.1.0.0
 bottle-haml==0.1.4
 bottle==0.12.9
+cffi==1.7.0
 certifi==2015.04.28
 configparser==3.5.0
 gunicorn==19.4.5


### PR DESCRIPTION
Next attempt. Current version of cffi is 1.7.0 in both Docker container and Pi.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/465)
<!-- Reviewable:end -->
