### PR TITLE
Update URL to new domain, force HTTPS only

### DIFF
--- a/bin/run_upgrade.sh
+++ b/bin/run_upgrade.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-bash <(curl -sL https://www.screenlyapp.com/install-ose.sh)
+bash <(curl -sL --proto '=https' https://www.screenly.io/install-ose.sh)


### PR DESCRIPTION
--proto '=https' forces curl to only use https:// which will prevent another http:// redirect mistake from occurring anywhere in the chain

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/482)
<!-- Reviewable:end -->
