### PR TITLE
Use https:// for GitHub repo

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -61,7 +61,7 @@ sudo apt-get install -y python-dev git-core libffi-dev libssl-dev
 curl -s https://bootstrap.pypa.io/get-pip.py | sudo python
 sudo pip install ansible==2.1.0.0
 
-ansible localhost -m git -a "repo=${1:-http://github.com/wireload/screenly-ose.git} dest=/home/pi/screenly version=$BRANCH"
+ansible localhost -m git -a "repo=${1:-https://github.com/wireload/screenly-ose.git} dest=/home/pi/screenly version=$BRANCH"
 cd /home/pi/screenly/ansible
 
 ansible-playbook site.yml $EXTRA_ARGS


### PR DESCRIPTION
GitHub does a 301 from http:// to https:// - we can avoid the redirect and interception risk if https:// is used directly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wireload/screenly-ose/483)
<!-- Reviewable:end -->
