### PR TITLE
exception handling

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -222,11 +222,14 @@ def view_video(uri, duration):
     run = sh.Command(player_args[0])(*player_args[1:], **player_kwargs)
 
     browser_clear(force=True)
-    while run.process.alive:
-        watchdog()
-        sleep(1)
-    if run.exit_code == 124:
-        logging.error('omxplayer timed out')
+    try:
+        while run.process.alive:
+            watchdog()
+            sleep(1)
+        if run.exit_code == 124:
+            logging.error('omxplayer timed out')
+    except sh.ErrorReturnCode_1:
+        logging.info('Resource URI is not correct, remote host is not responding or request was rejected.')
 
 
 def check_update():


### PR DESCRIPTION
Added exception handling during video playback, as unforeseen situations are possible. 
For example, on the hosting with video the limit of requests is established. In this case, sometimes the following happens: asset is passed check in url_fails function, but when trying to play the video the request is rejected, which causes viewer to crash.